### PR TITLE
Profiles now show 1 decimal place in "Top %"

### DIFF
--- a/default.conf
+++ b/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  location ~* \.(jpg|jpeg|png|svg|gif|ico|css|js|woff|woff2|ttf)$ {
+  location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
     root   /usr/share/nginx/html;
     index  index.html index.htm;
     try_files $uri $uri/ /index.html;

--- a/default.conf
+++ b/default.conf
@@ -1,6 +1,6 @@
 server {
   listen 80;
-  location ~* \.(jpg|jpeg|png|gif|ico|css|js)$ {
+  location ~* \.(jpg|jpeg|png|svg|gif|ico|css|js|woff|woff2|ttf)$ {
     root   /usr/share/nginx/html;
     index  index.html index.htm;
     try_files $uri $uri/ /index.html;

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -126,19 +126,13 @@ export default class ModeStatsGrid extends Vue {
       return "";
     }
     const quantilePerc = modeStat.quantile * 100;
-    let topPerc
-
-    if (quantilePerc > 95) {
-      topPerc =  100 - quantilePerc
-    } else {
-      topPerc = Math.ceil(100 - quantilePerc);
-    }
+    const topPerc = 100 - quantilePerc
 
     if (topPerc > 90) {
       return "";
     }
 
-      return (topPerc < 5 ? `top ${Math.max(topPerc,0.1).toFixed(1)}%` : `top ${topPerc}%`)
+      return `top ${Math.max(topPerc,0.1).toFixed(1)}%`
   }
 
   public headers = [

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -138,7 +138,7 @@ export default class ModeStatsGrid extends Vue {
       return "";
     }
 
-      return (topPerc < 5 ? `top ${Math.max(topPerc,0.1).toFixed(1)}` : `top ${topPerc}`)
+      return (topPerc < 5 ? `top ${Math.max(topPerc,0.1).toFixed(1)}%` : `top ${topPerc}%`)
   }
 
   public headers = [

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -45,6 +45,7 @@ import { Component, Prop } from "vue-property-decorator";
 import { EGameMode } from "@/store/typings";
 import { ModeStat } from "@/store/player/types";
 import RaceIcon from "@/components/player/RaceIcon.vue";
+import { toInteger } from 'lodash';
 
 @Component({
   components: { RaceIcon },
@@ -126,13 +127,19 @@ export default class ModeStatsGrid extends Vue {
       return "";
     }
     const quantilePerc = modeStat.quantile * 100;
-    const topPerc = Math.ceil(100 - quantilePerc);
+    let topPerc
+
+    if (quantilePerc > 95) {
+      topPerc =  100 - quantilePerc
+    } else {
+      topPerc = Math.ceil(100 - quantilePerc);
+    }
 
     if (topPerc > 90) {
       return "";
     }
 
-    return `top ${Math.max(topPerc, 1)}%`;
+      return (topPerc < 5 ? `top ${Math.max(topPerc,0.1).toFixed(1)}` : `top ${topPerc}`)
   }
 
   public headers = [

--- a/src/components/player/ModeStatsGrid.vue
+++ b/src/components/player/ModeStatsGrid.vue
@@ -45,7 +45,6 @@ import { Component, Prop } from "vue-property-decorator";
 import { EGameMode } from "@/store/typings";
 import { ModeStat } from "@/store/player/types";
 import RaceIcon from "@/components/player/RaceIcon.vue";
-import { toInteger } from 'lodash';
 
 @Component({
   components: { RaceIcon },


### PR DESCRIPTION
UPDATE: applying this to ALL players, not just Top 5%

Top 5% players can now get an additional decimal place of accuracy on their percentile:

From the number 1 player profile, showing Math.max still works:
![Screenshot from 2020-10-02 13-24-52](https://user-images.githubusercontent.com/40397054/94923914-89f39b00-04b4-11eb-9434-9d088689a7f8.png)

From top 5% profile showing different gamemodes:
![Screenshot from 2020-10-02 13-39-27](https://user-images.githubusercontent.com/40397054/94924050-bf988400-04b4-11eb-8eff-c61f21bc0264.png)

From >Top 5%:
![Screenshot from 2020-10-02 13-25-01](https://user-images.githubusercontent.com/40397054/94924072-c8895580-04b4-11eb-8fb9-77f153acbdb4.png)
