### PR TITLE
Functional improvements to MMR Distribution page

### DIFF
--- a/src/components/overal-statistics/BarChart.vue
+++ b/src/components/overal-statistics/BarChart.vue
@@ -37,6 +37,13 @@ export default class BarChart extends Mixins(Bar) {
           },
         },
       ],
+      xAxes: [
+        {
+          ticks: {
+            reverse: true,
+          },
+        },
+      ],
     },
   };
 

--- a/src/components/overal-statistics/tabs/MmrDistributionTab.vue
+++ b/src/components/overal-statistics/tabs/MmrDistributionTab.vue
@@ -13,7 +13,10 @@
           />
         </v-card-text>
         <v-card-text>
-          Pink bars mark top 3%, 5%, 10%, 25% and 50% of players, green is you
+          The purple bars mark top: 3%, 5%, 10%, 25% and 50% of players.
+        </v-card-text>
+        <v-card-text v-if="authCode">
+          The green bar shows where you are in the distribution.
         </v-card-text>
       </v-col>
       <v-col cols="md-10">
@@ -75,6 +78,10 @@ export default class PlayerActivityTab extends Vue {
 
   get mmrDistribution() {
     return this.$store.direct.state.overallStatistics.mmrDistribution;
+  }
+
+  get authCode(): string {
+    return this.$store.direct.state.oauth.token;
   }
 }
 </script>

--- a/src/components/overal-statistics/tabs/MmrDistributionTab.vue
+++ b/src/components/overal-statistics/tabs/MmrDistributionTab.vue
@@ -13,7 +13,7 @@
           />
         </v-card-text>
         <v-card-text>
-          The purple bars mark top: 3%, 5%, 10%, 25% and 50% of players.
+          The purple bars mark top: 2%, 5%, 10%, 25% and 50% of players.
         </v-card-text>
         <v-card-text v-if="authCode">
           The green bar shows where you are in the distribution.


### PR DESCRIPTION
When logged in:

![loggedin](https://user-images.githubusercontent.com/40397054/95337556-dcb0c680-08a9-11eb-91b8-4f458a4307e8.PNG)

when logged out:

![loggedout](https://user-images.githubusercontent.com/40397054/95337573-e1757a80-08a9-11eb-9428-ea53539fa867.PNG)

This actually revealed a very minor bug from before, that the graph should re-draw if someone logs out while on the page (to remove the green bar in the graph), not fixed, but too minor and unlikely to occur anyway.

In addition, the text says "Top 3%" but the code says "Top 2%". I'm not certain which is correct, but I've changed the text to match the code in any case. (Screenshots above were taken before including this change)
![2percent](https://user-images.githubusercontent.com/40397054/95338148-85f7bc80-08aa-11eb-83ee-e56785f0106c.PNG)

EDIT: Also inverted the X axis for the MMR distribution so it reads left-to-right now.