### PR TITLE
added new css style for scrollable dialog and applied it in user icon…

### DIFF
--- a/src/components/player/PlayerAvatar.vue
+++ b/src/components/player/PlayerAvatar.vue
@@ -81,7 +81,7 @@
       </v-col>
     </v-row>
 
-    <v-dialog v-model="dialogOpened" scrollable max-width="1400px" >
+    <v-dialog v-model="dialogOpened" max-width="1400px" class="scroll-v-dialog">
       <v-card>
         <v-checkbox
          style="margin-left:25px"

--- a/src/scss/shared/overrides.scss
+++ b/src/scss/shared/overrides.scss
@@ -134,3 +134,8 @@ h3 {
 .row {
   filter: blur(0);
 }
+
+.scroll-v-dialog {
+  background: inherit !important;
+  overflow-y: scroll !important;
+}


### PR DESCRIPTION
I added a new css class for the dialog, which was not able to be scrollable by default somehow.

In the PlayerAvatar i let the dialog inherit from the scss. 

Please let me know what you think or if something needs to be changed.

The Result is that the you can scroll down when the height of the page gets too small.