### PR TITLE
changed Macedonia to North Macedonia

### DIFF
--- a/src/store/countries.ts
+++ b/src/store/countries.ts
@@ -128,7 +128,7 @@ export enum ECountries {
   Lithuania = "LT",
   Luxembourg = "LU",
   Macao = "MO",
-  Macedonia = "MK",
+  "North Macedonia" = "MK",
   Madagascar = "MG",
   Malawi = "MW",
   Malaysia = "MY",


### PR DESCRIPTION
Corrected the name from:
"Macedonia" to "North Macedonia"

![northmacedonia](https://user-images.githubusercontent.com/40397054/97856651-7d04da00-1cf4-11eb-97b4-5692a0d857e2.PNG)
