### PR TITLE
added missing spaces on ranking tabs (@ player page)

### DIFF
--- a/src/components/player/PlayerLeague.vue
+++ b/src/components/player/PlayerLeague.vue
@@ -19,8 +19,8 @@
         <br v-if="showAtPartner" />
       </div>
       <span v-if="isRanked">
-        <span v-if="!smallMode">Rank</span>
-        <span v-if="!smallMode" class="number-text">{{ modeStat.rank }} |</span>
+        <span v-if="!smallMode">Rank </span>
+        <span v-if="!smallMode" class="number-text">{{ modeStat.rank }} | </span>
         <span class="won">{{ modeStat.wins }}</span>
         -
         <span class="lost">{{ modeStat.losses }}</span>


### PR DESCRIPTION
each placement tab was missing spaces in the rank/score line
e.g. "Rank13 |16-14" instead of "Rank 13 | 16-14"