### PR TITLE
Player MMR Timeline

### DIFF
--- a/src/components/overal-statistics/LineChart.vue
+++ b/src/components/overal-statistics/LineChart.vue
@@ -8,6 +8,7 @@ import { ChartData } from "chart.js";
 })
 export default class LineChart extends Mixins(Line) {
   @Prop() public chartData!: ChartData;
+  @Prop() public beginYAxisAtZero?: boolean;
 
   private options = {
     legend: {
@@ -40,6 +41,19 @@ export default class LineChart extends Mixins(Line) {
   };
 
   mounted() {
+    let gradient = this.$refs.canvas
+      .getContext("2d")
+      .createLinearGradient(0, 0, 0, this.height);
+    gradient.addColorStop(0.1, "rgba(54, 162, 235, 0.5)");
+    gradient.addColorStop(0.3, "rgba(54, 162, 235, 0.25)");
+    gradient.addColorStop(0.6, "rgba(54, 162, 235, 0.1)");
+    gradient.addColorStop(0.85, "rgba(54, 162, 235, 0.0)");
+    if (this.chartData.datasets) {
+      this.chartData.datasets[0].backgroundColor = gradient;
+    }
+    if (this.beginYAxisAtZero !== undefined) {
+      this.options.scales.yAxes[0].ticks.beginAtZero = this.beginYAxisAtZero;
+    }
     if (this.chartData) {
       this.renderChart(this.chartData, this.options);
     }

--- a/src/components/player/PlayerMmrTimelineChart.vue
+++ b/src/components/player/PlayerMmrTimelineChart.vue
@@ -1,0 +1,52 @@
+<template>
+  <div>
+    <line-chart
+      ref="chart"
+      :chart-data="mmrChartData"
+      :begin-y-axis-at-zero="false"
+    />
+  </div>
+</template>
+<script lang="ts">
+import { Component, Prop } from "vue-property-decorator";
+import { PlayerMmrTimeline } from "@/store/player/types";
+import moment from "moment";
+import LineChart from "@/components/overal-statistics/LineChart.vue";
+import Vue from "vue";
+import { ChartData } from "chart.js";
+
+@Component({
+  components: { LineChart },
+})
+export default class PlayerMmrTimelineChart extends Vue {
+  @Prop() public mmrTimeline!: PlayerMmrTimeline;
+
+  get mmrValues(): number[] {
+    return this.mmrTimeline.mmrAtTimes.map((m) => m.mmr);
+  }
+
+  get mmrDates(): string[] {
+    return this.mmrTimeline.mmrAtTimes.map((m) =>
+      moment(m.mmrTime).format("LL")
+    );
+  }
+
+  get mmrChartData(): ChartData {
+    return {
+      labels: this.mmrDates,
+      datasets: [
+        {
+          label: "MMR",
+          data: this.mmrValues,
+          borderColor: "rgba(54, 162, 235, 1)",
+          borderWidth: 1.0,
+          pointStyle: "circle",
+          pointRadius: 1.2,
+          pointBorderWidth: 1.8,
+          lineTension: 0.0,
+        },
+      ],
+    };
+  }
+}
+</script>

--- a/src/services/ProfileService.ts
+++ b/src/services/ProfileService.ts
@@ -1,11 +1,13 @@
 import {
   ModeStat,
+  PlayerMmrTimeline,
   PlayerProfile,
   PlayerStatsRaceOnMapVersusRace,
   RaceStat,
 } from "@/store/player/types";
 import { API_URL } from "@/main";
 import { Gateways } from "@/store/ranking/types";
+import { ERaceEnum, EGameMode } from "@/store/typings";
 
 export default class ProfileService {
   public async retrieveWinRate(
@@ -85,7 +87,6 @@ export default class ProfileService {
 
     return await response.json();
   }
-
   public async retrievePlayerStatsRaceVersusRaceOnMap(
     battleTag: string,
     season: number
@@ -93,6 +94,21 @@ export default class ProfileService {
     const url = `${API_URL}api/player-stats/${encodeURIComponent(
       battleTag
     )}/race-on-map-versus-race?season=${season}`;
+
+    const response = await fetch(url);
+    return await response.json();
+  }
+
+  public async retrievePlayerMmrTimeline(
+    battleTag: string,
+    race: ERaceEnum,
+    gateWay: Gateways,
+    season: number,
+    gameMode: EGameMode
+  ): Promise<PlayerMmrTimeline> {
+    const url = `${API_URL}api/players/${encodeURIComponent(
+      battleTag
+    )}/mmr-timeline?race=${race}&gateWay=${gateWay}&season=${season}&gameMode=${gameMode}`;
 
     const response = await fetch(url);
     return await response.json();

--- a/src/services/ProfileService.ts
+++ b/src/services/ProfileService.ts
@@ -105,12 +105,16 @@ export default class ProfileService {
     gateWay: Gateways,
     season: number,
     gameMode: EGameMode
-  ): Promise<PlayerMmrTimeline> {
+  ): Promise<PlayerMmrTimeline | undefined> {
     const url = `${API_URL}api/players/${encodeURIComponent(
       battleTag
     )}/mmr-timeline?race=${race}&gateWay=${gateWay}&season=${season}&gameMode=${gameMode}`;
 
     const response = await fetch(url);
-    return await response.json();
+    if (response.ok && response.status == 200) {
+      return await response.json();
+    } else {
+      return undefined;
+    }
   }
 }

--- a/src/store/player/index.ts
+++ b/src/store/player/index.ts
@@ -5,8 +5,9 @@ import {
   PlayerStatsRaceOnMapVersusRace,
   ModeStat,
   RaceStat,
+  PlayerMmrTimeline,
 } from "./types";
-import { EGameMode, Match, RootState } from "../typings";
+import { EGameMode, ERaceEnum, Match, RootState } from "../typings";
 import { ActionContext } from "vuex";
 import { Season, Gateways } from "@/store/ranking/types";
 import GatewaysService from "@/services/GatewaysService";
@@ -22,12 +23,14 @@ const mod = {
     matches: [] as Match[],
     loadingProfile: false,
     loadingRecentMatches: false,
+    loadingMmrTimeline: false,
     opponentTag: "",
     selectedSeason: {} as Season,
     gameMode: 0 as EGameMode,
     ongoingMatch: {} as Match,
     gameModeStats: [] as ModeStat[],
     raceStats: [] as RaceStat[],
+    mmrTimeline: {} as PlayerMmrTimeline,
   } as PlayerState,
   actions: {
     async loadProfile(
@@ -136,6 +139,25 @@ const mod = {
         await dispatch.loadGameModeStats({});
       }
     },
+    async loadPlayerMmrTimeline(
+      context: ActionContext<PlayerState, RootState>
+    ) {
+      const { commit, rootGetters, state, rootState } = moduleActionContext(
+        context,
+        mod
+      );
+      commit.SET_LOADING_MMR_TIMELINE(true);
+      const mmrTimeline = await rootGetters.profileService.retrievePlayerMmrTimeline(
+        state.battleTag,
+        // TOOD: replace race with something interactible
+        ERaceEnum.HUMAN,
+        rootState.gateway,
+        0, //state.selectedSeason?.id ?? -1,
+        1 //state.gameMode
+      );
+      commit.SET_MMR_TIMELINE(mmrTimeline);
+      commit.SET_LOADING_MMR_TIMELINE(false);
+    },
   },
   mutations: {
     SET_PROFILE(state: PlayerState, profile: PlayerProfile) {
@@ -155,6 +177,9 @@ const mod = {
     },
     SET_LOADING_RECENT_MATCHES(state: PlayerState, loading: boolean) {
       state.loadingRecentMatches = loading;
+    },
+    SET_LOADING_MMR_TIMELINE(state: PlayerState, loading: boolean) {
+      state.loadingMmrTimeline = loading;
     },
     SET_BATTLE_TAG(state: PlayerState, battleTag: string) {
       state.battleTag = battleTag;
@@ -182,6 +207,9 @@ const mod = {
     },
     SET_RACE_STATS(state: PlayerState, stats: RaceStat[]) {
       state.raceStats = stats;
+    },
+    SET_MMR_TIMELINE(state: PlayerState, mmrTimeline: PlayerMmrTimeline) {
+      state.mmrTimeline = mmrTimeline;
     },
   },
 } as const;

--- a/src/store/player/index.ts
+++ b/src/store/player/index.ts
@@ -27,10 +27,11 @@ const mod = {
     opponentTag: "",
     selectedSeason: {} as Season,
     gameMode: 0 as EGameMode,
+    race: 0 as ERaceEnum,
     ongoingMatch: {} as Match,
     gameModeStats: [] as ModeStat[],
     raceStats: [] as RaceStat[],
-    mmrTimeline: {} as PlayerMmrTimeline,
+    mmrTimeline: {} as PlayerMmrTimeline | undefined,
   } as PlayerState,
   actions: {
     async loadProfile(
@@ -137,6 +138,7 @@ const mod = {
         await dispatch.loadMatches(1);
         await dispatch.loadRaceStats();
         await dispatch.loadGameModeStats({});
+        await dispatch.loadPlayerMmrTimeline();
       }
     },
     async loadPlayerMmrTimeline(
@@ -149,11 +151,10 @@ const mod = {
       commit.SET_LOADING_MMR_TIMELINE(true);
       const mmrTimeline = await rootGetters.profileService.retrievePlayerMmrTimeline(
         state.battleTag,
-        // TOOD: replace race with something interactible
-        ERaceEnum.HUMAN,
+        state.race,
         rootState.gateway,
-        0, //state.selectedSeason?.id ?? -1,
-        1 //state.gameMode
+        state.selectedSeason?.id ?? -1,
+        state.gameMode
       );
       commit.SET_MMR_TIMELINE(mmrTimeline);
       commit.SET_LOADING_MMR_TIMELINE(false);
@@ -199,6 +200,9 @@ const mod = {
     SET_GAMEMODE(state: PlayerState, gameMode: EGameMode) {
       state.gameMode = gameMode;
     },
+    SET_RACE(state: PlayerState, race: ERaceEnum) {
+      state.race = race;
+    },
     SET_ONGOING_MATCH(state: PlayerState, match: Match) {
       state.ongoingMatch = match;
     },
@@ -208,7 +212,10 @@ const mod = {
     SET_RACE_STATS(state: PlayerState, stats: RaceStat[]) {
       state.raceStats = stats;
     },
-    SET_MMR_TIMELINE(state: PlayerState, mmrTimeline: PlayerMmrTimeline) {
+    SET_MMR_TIMELINE(
+      state: PlayerState,
+      mmrTimeline: PlayerMmrTimeline | undefined
+    ) {
       state.mmrTimeline = mmrTimeline;
     },
   },

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -15,10 +15,11 @@ export type PlayerState = {
   opponentTag: string;
   selectedSeason: Season;
   gameMode: EGameMode;
+  race: ERaceEnum;
   raceStats: RaceStat[];
   ongoingMatch: Match;
   gameModeStats: ModeStat[];
-  mmrTimeline: PlayerMmrTimeline;
+  mmrTimeline: PlayerMmrTimeline | undefined;
 };
 
 export type PlayerProfile = {
@@ -89,9 +90,4 @@ export type MmrAtTime = {
 
 export type PlayerMmrTimeline = {
   mmrAtTimes: MmrAtTime[];
-  // Are the following even needed?
-  battleTag: string;
-  race: ERaceEnum;
-  season: number;
-  gameMode: EGameMode;
 };

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -1,5 +1,6 @@
 import { EGameMode, ERaceEnum, Match } from "../typings";
 import { Season, Gateways, PlayerId } from "@/store/ranking/types";
+import { Moment } from "moment";
 
 export type PlayerState = {
   playerStatsRaceVersusRaceOnMap: PlayerStatsRaceOnMapVersusRace;
@@ -10,12 +11,14 @@ export type PlayerState = {
   matches: Match[];
   loadingRecentMatches: boolean;
   loadingProfile: boolean;
+  loadingMmrTimeline: boolean;
   opponentTag: string;
   selectedSeason: Season;
   gameMode: EGameMode;
   raceStats: RaceStat[];
   ongoingMatch: Match;
   gameModeStats: ModeStat[];
+  mmrTimeline: PlayerMmrTimeline;
 };
 
 export type PlayerProfile = {
@@ -78,3 +81,17 @@ export interface PlayerStatsRaceOnMapVersusRace {
   raceWinsOnMap: RaceWinsOnMap[];
   id: string;
 }
+
+export type MmrAtTime = {
+  mmr: number;
+  mmrTime: Moment;
+};
+
+export type PlayerMmrTimeline = {
+  mmrAtTimes: MmrAtTime[];
+  // Are the following even needed?
+  battleTag: string;
+  race: ERaceEnum;
+  season: number;
+  gameMode: EGameMode;
+};

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -206,6 +206,7 @@ export default class PlayerView extends Vue {
     this.$store.direct.dispatch.player.loadPlayerStatsRaceVersusRaceOnMap(
       this.battleTag
     );
+    this.$store.direct.dispatch.player.loadPlayerMmrTimeline();
   }
 
   get seasons() {
@@ -329,7 +330,6 @@ export default class PlayerView extends Vue {
     await this.$store.direct.dispatch.player.loadPlayerStatsRaceVersusRaceOnMap(
       this.battleTag
     );
-
     await this.$store.direct.dispatch.player.loadOngoingPlayerMatch(
       this.battleTag
     );


### PR DESCRIPTION
This relates to issue https://github.com/w3champions/w3champions-ui/issues/215
Adds a player mmr timeline to the player profile
![grafik](https://user-images.githubusercontent.com/73471359/99558365-f1fa3400-29c3-11eb-8a45-19c3cd9064ab.png)

Please note that I changed the linechart.js to apply a gradient effect. Hence the linecharts on the statistics page will also have this effect. Imo this is nice, so I didn't bother changing it.
![grafik](https://user-images.githubusercontent.com/73471359/99558531-22da6900-29c4-11eb-8816-39476989c692.png)
