### PR TITLE
MMR/RP timeline Bugfix: Fixes bug that prevented timeline from loading if /player/statistics …

### DIFF
--- a/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
@@ -43,11 +43,21 @@ export default class PlayerStatsRaceVersusRaceOnMap extends Vue {
     return this.$store.direct.state.player.isInitialized;
   }
 
+  mounted(): void {
+    if (this.isPlayerInitialized) {
+      this.setSelectedTab();
+    }
+  }
+
+  // When loading the statistics tab via URL directly, due to Lifecycle Hooks the mounted() here
+  // is called before mounted of player, which this depends on. For this case isPlayerInitialized
+  // is being watched to set the tab once player.vue init() has finished.
   @Watch("isPlayerInitialized")
   onPlayerInitialized(): void {
     this.setSelectedTab();
   }
-  setSelectedTab() {
+
+  setSelectedTab(): void {
     let maxRace = ERaceEnum.RANDOM;
     let maxGames = 0;
     this.stats

--- a/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
+++ b/src/components/player/PlayerStatsRaceVersusRaceOnMap.vue
@@ -24,7 +24,7 @@
 
 <script lang="ts">
 import Vue from "vue";
-import { Component, Prop } from "vue-property-decorator";
+import { Component, Prop, Watch } from "vue-property-decorator";
 import { RaceWinsOnMap } from "@/store/player/types";
 import RaceToMapStat from "@/components/overal-statistics/RaceToMapStat.vue";
 import { ERaceEnum } from "@/store/typings";
@@ -39,7 +39,15 @@ export default class PlayerStatsRaceVersusRaceOnMap extends Vue {
   public raceEnums = ERaceEnum;
   public selectedTab = "tab-1";
 
-  mounted() {
+  get isPlayerInitialized(): boolean {
+    return this.$store.direct.state.player.isInitialized;
+  }
+
+  @Watch("isPlayerInitialized")
+  onPlayerInitialized(): void {
+    this.setSelectedTab();
+  }
+  setSelectedTab() {
     let maxRace = ERaceEnum.RANDOM;
     let maxGames = 0;
     this.stats

--- a/src/components/player/tabs/PlayerStatisticTab.vue
+++ b/src/components/player/tabs/PlayerStatisticTab.vue
@@ -58,7 +58,7 @@
       <v-col cols="12" md="10">
         <v-card-text v-if="!loadingMmrRpTimeline">
           <player-mmr-rp-timeline-chart
-            style="position: relative;"
+            style="position: relative"
             :mmrRpTimeline="playerMmrRpTimeline"
           />
           <v-card-text v-if="isPlayerMmrRpTimelineEmpty">
@@ -121,6 +121,14 @@ export default class PlayerStatisticTab extends Vue {
     return this.$store.direct.state.player.isInitialized;
   }
 
+  mounted(): void {
+    if (this.isPlayerInitialized) {
+      this.initMmrRpTimeline();
+    }
+  }
+  // When loading the statistics tab via URL directly, due to Lifecycle Hooks the mounted() here
+  // is called before mounted of player, which this depends on. For this case isPlayerInitialized
+  // is being watched to init the mmrRpTimeline once player.vue init() has finished.
   @Watch("isPlayerInitialized")
   onPlayerInitialized(): void {
     this.initMmrRpTimeline();
@@ -141,16 +149,16 @@ export default class PlayerStatisticTab extends Vue {
     this.selectedGameMode = EGameMode.GM_1ON1;
     this.selectedRace = maxRace;
 
-    await this.$store.direct.dispatch.player.loadPlayerMmrRpTimeline();
+    this.$store.direct.dispatch.player.loadPlayerMmrRpTimeline();
   }
 
   private async setTimelineMode(mode: EGameMode) {
     this.$store.direct.commit.player.SET_GAMEMODE(mode);
-    await this.$store.direct.dispatch.player.loadPlayerMmrRpTimeline();
+    this.$store.direct.dispatch.player.loadPlayerMmrRpTimeline();
   }
   private async setTimelineRace(race: ERaceEnum) {
     this.$store.direct.commit.player.SET_RACE(race);
-    await this.$store.direct.dispatch.player.loadPlayerMmrRpTimeline();
+    this.$store.direct.dispatch.player.loadPlayerMmrRpTimeline();
   }
 
   get patches() {

--- a/src/store/player/index.ts
+++ b/src/store/player/index.ts
@@ -15,6 +15,7 @@ import GatewaysService from "@/services/GatewaysService";
 const mod = {
   namespaced: true,
   state: {
+    isInitialized: false,
     playerStatsRaceVersusRaceOnMap: {} as PlayerStatsRaceOnMapVersusRace,
     battleTag: "",
     page: 0,
@@ -36,14 +37,18 @@ const mod = {
   actions: {
     async loadProfile(
       context: ActionContext<PlayerState, RootState>,
-      params: { battleTag: string, freshLogin: boolean }
+      params: { battleTag: string; freshLogin: boolean }
     ) {
-      const { commit, rootState, rootGetters } = moduleActionContext(context, mod);
+      const { commit, rootState, rootGetters } = moduleActionContext(
+        context,
+        mod
+      );
 
       commit.SET_LOADING_PROFILE(true);
 
       const profile = await rootGetters.profileService.retrieveProfile(
-        params.battleTag, params.freshLogin ? rootState.oauth.token : null
+        params.battleTag,
+        params.freshLogin ? rootState.oauth.token : null
       );
 
       commit.SET_PROFILE(profile);
@@ -161,6 +166,9 @@ const mod = {
     },
   },
   mutations: {
+    SET_INITIALIZED(state: PlayerState) {
+      state.isInitialized = true;
+    },
     SET_PROFILE(state: PlayerState, profile: PlayerProfile) {
       state.playerProfile = profile;
     },

--- a/src/store/player/types.ts
+++ b/src/store/player/types.ts
@@ -3,6 +3,7 @@ import { Season, Gateways, PlayerId } from "@/store/ranking/types";
 import { Moment } from "moment";
 
 export type PlayerState = {
+  isInitialized: boolean;
   playerStatsRaceVersusRaceOnMap: PlayerStatsRaceOnMapVersusRace;
   page: number;
   battleTag: string;

--- a/src/views/Player.vue
+++ b/src/views/Player.vue
@@ -340,7 +340,7 @@ export default class PlayerView extends Vue {
         this.battleTag
       );
     }, AppConstants.ongoingMatchesRefreshInterval);
-
+  this.$store.direct.commit.player.SET_INITIALIZED();
     window.scrollTo(0, 0);
   }
 


### PR DESCRIPTION
Fixes bug that prevented timeline from loading if /player/statistics was directly loaded via URL. 

Also fixes the related bug for Matchup Statistics. On prod the correct tab is also not loaded.

The bug is that mounted calls of children are done before player.vue init is finished, so necessary data is not loaded in time.
The fix is adding an isInitialized state to player store, which is watched by children.

Directly loading via URL currently:
![grafik](https://user-images.githubusercontent.com/73471359/100486184-3cd22500-3103-11eb-8411-314e977724dc.png)

After fix:
![grafik](https://user-images.githubusercontent.com/73471359/100486266-7acf4900-3103-11eb-8e39-27c16734abcb.png)

Related to https://github.com/w3champions/w3champions-ui/issues/294