### PR TITLE
Increase items per page on race->maps stats table.

### DIFF
--- a/src/components/overal-statistics/RaceToMapStat.vue
+++ b/src/components/overal-statistics/RaceToMapStat.vue
@@ -3,6 +3,7 @@
     <v-data-table
       :headers="headers"
       :items="stats"
+      :items-per-page="Number.POSITIVE_INFINITY"
       hide-default-footer
       :mobile-breakpoint="400"
       :hidden="stats.length === 0"


### PR DESCRIPTION
By default the Vuetify table component will only display 10 items
per page. This increases the limit to Number.POSITIVE_INFINITY
as it is very unlikely for the maps list to grow out of control
and any lower number would be arbitrary.

resolves #301 