### PR TITLE
Soviet Union Flag Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12391,9 +12391,9 @@
       }
     },
     "vue-country-flag": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/vue-country-flag/-/vue-country-flag-2.0.2.tgz",
-      "integrity": "sha512-hRK0ZLcbQNdTo5H4UFOUoN6Tqy0BwepmaG1BNuf6cMyEWRQCkcbwBv0CQJXiNhPI+VYt/DyndQMT+E1/H82F/Q=="
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/vue-country-flag/-/vue-country-flag-2.0.3.tgz",
+      "integrity": "sha512-QZM3hNNhnGU+G1qnpq1BiICE4Zh91UA++/UpM0go8XbxkVxTiPy4asWY07vL/3PtW8M69YqWVbhwG13rzvNwkA=="
     },
     "vue-eslint-parser": {
       "version": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "vue-chartjs": "^3.5.1",
     "vue-class-component": "^7.2.6",
     "vue-cookies-ts": "^1.5.19",
-    "vue-country-flag": "^2.0.2",
+    "vue-country-flag": "^2.0.3",
     "vue-i18n": "^8.22.2",
     "vue-markdown": "^2.2.4",
     "vue-moment": "^4.1.0",

--- a/src/store/countries.ts
+++ b/src/store/countries.ts
@@ -205,6 +205,7 @@ export enum ECountries {
   Somalia = "SO",
   "South Africa" = "ZA",
   "South Georgia And Sandwich Island" = "GS",
+  "Soviet Union" => "SU",
   Spain = "ES",
   SriLanka = "LK",
   Sudan = "SD",


### PR DESCRIPTION
Following updated vue-country-flag library https://github.com/P3trur0/vue-country-flag/releases/tag/v2.0.3

https://www.npmjs.com/package/vue-country-flag/v/2.0.3

Requested by several people, including myself. Please accept.