### PR TITLE
Fix larger team mode stats

### DIFF
--- a/src/components/match-details/PlayerPerformanceOnMatch.vue
+++ b/src/components/match-details/PlayerPerformanceOnMatch.vue
@@ -1,87 +1,75 @@
 <template>
   <div>
-    <v-row dense>
-      <v-col :order="left ? 0 : 2" :align="left ? 'right' : 'left'">
-        Units killed
+    <v-row dense :class="left ? 'justify-end' : 'justify-start'">
+      <!-- <v-col :order="0" cols="1"></v-col> -->
+      <v-col :order="left ? 1 : 3" class="col-md-auto">
+        <v-row dense>
+          <v-col :align="left ? 'right' : 'left'">
+            Units killed
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :align="left ? 'right' : 'left'">
+            Units produced
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :align="left ? 'right' : 'left'">
+            Gold mined
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :align="left ? 'right' : 'left'">
+            Lumber harvested
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :align="left ? 'right' : 'left'">
+            Upkeep lost
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :align="left ? 'right' : 'left'">
+            Largest army
+          </v-col>
+        </v-row>
       </v-col>
       <v-col :order="1" cols="1"></v-col>
       <v-col
-        :class="unitsKilledComparison"
-        :order="left ? 2 : 0"
-        :cols="is2v2 ? 3 : 2"
+        class="col-md-auto"
+        :order="left ? 3 : 0"
         :align="left ? 'left' : 'right'"
       >
-        {{ unitScore.map((r) => r.unitsKilled).join(" + ") }}
-      </v-col>
-    </v-row>
-    <v-row dense>
-      <v-col :order="left ? 0 : 2" :align="left ? 'right' : 'left'">
-        Units produced
-      </v-col>
-      <v-col :order="1" cols="1"></v-col>
-      <v-col
-        :class="unitsProducedComparison"
-        :order="left ? 2 : 0"
-        :cols="is2v2 ? 3 : 2"
-        :align="left ? 'left' : 'right'"
-      >
-        {{ unitScore.map((r) => r.unitsProduced).join(" + ") }}
-      </v-col>
-    </v-row>
-    <v-row dense>
-      <v-col :order="left ? 0 : 2" :align="left ? 'right' : 'left'">
-        Gold mined
-      </v-col>
-      <v-col :order="1" cols="1"></v-col>
-      <v-col
-        :class="goldComparison"
-        :order="left ? 2 : 0"
-        :cols="is2v2 ? 3 : 2"
-        :align="left ? 'left' : 'right'"
-      >
-        {{ resourceScoure.map((r) => r.goldCollected).join(" + ") }}
-      </v-col>
-    </v-row>
-    <v-row dense>
-      <v-col :order="left ? 0 : 2" :align="left ? 'right' : 'left'">
-        Lumber harvested
-      </v-col>
-      <v-col :order="1" cols="1"></v-col>
-      <v-col
-        :class="woodComparison"
-        :order="left ? 2 : 0"
-        :cols="is2v2 ? 3 : 2"
-        :align="left ? 'left' : 'right'"
-      >
-        {{ resourceScoure.map((r) => r.lumberCollected).join(" + ") }}
-      </v-col>
-    </v-row>
-    <v-row dense>
-      <v-col :order="left ? 0 : 2" :align="left ? 'right' : 'left'">
-        Upkeep lost
-      </v-col>
-      <v-col :order="1" cols="1"></v-col>
-      <v-col
-        :class="upkeepComparison"
-        :order="left ? 2 : 0"
-        :cols="is2v2 ? 3 : 2"
-        :align="left ? 'left' : 'right'"
-      >
-        {{ resourceScoure.map((r) => r.goldUpkeepLost).join(" + ") }}
-      </v-col>
-    </v-row>
-    <v-row dense>
-      <v-col :order="left ? 0 : 2" :align="left ? 'right' : 'left'">
-        Largest army
-      </v-col>
-      <v-col :order="1" cols="1"></v-col>
-      <v-col
-        :class="armyComparison"
-        :order="left ? 2 : 0"
-        :cols="is2v2 ? 3 : 2"
-        :align="left ? 'left' : 'right'"
-      >
-        {{ unitScore.map((r) => r.largestArmy).join(" / ") }}
+        <v-row dense>
+          <v-col :class="unitsKilledComparison" :align="left ? 'right' : 'left'">
+            {{ unitScore.map((r) => r.unitsKilled).join(" + ") }}
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :class="unitsProducedComparison" :align="left ? 'right' : 'left'">
+            {{ unitScore.map((r) => r.unitsProduced).join(" + ") }}
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :class="goldComparison" :align="left ? 'right' : 'left'">
+            {{ resourceScoure.map((r) => r.goldCollected).join(" + ") }}
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :class="woodComparison" :align="left ? 'right' : 'left'">
+            {{ resourceScoure.map((r) => r.lumberCollected).join(" + ") }}
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :class="upkeepComparison" :align="left ? 'right' : 'left'">
+            {{ resourceScoure.map((r) => r.goldUpkeepLost).join(" + ") }}
+          </v-col>
+        </v-row>
+        <v-row dense>
+          <v-col :class="armyComparison" :align="left ? 'right' : 'left'">
+            {{ unitScore.map((r) => r.largestArmy).join(" / ") }}
+          </v-col>
+        </v-row>
       </v-col>
     </v-row>
   </div>
@@ -100,10 +88,6 @@ export default class PlayerPerformanceOnMatch extends Vue {
   @Prop() unitScoreOpponent!: UnitScore[];
   @Prop() resourceScoure!: ResourceScore[];
   @Prop() resourceScoureOpponent!: ResourceScore[];
-
-  get is2v2() {
-    return this.unitScore.length > 1;
-  }
 
   get goldComparison() {
     return this.comparison(

--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -84,9 +84,8 @@
               Sorry, but this games seems to have incomplete data
             </v-card-subtitle>
           </v-row>
-          <v-row v-if="isCompleteGame && !matchIsFFA">
-            <v-col :cols="0"></v-col>
-            <v-col cols="5">
+          <v-row v-if="isCompleteGame && !matchIsFFA" class="justify-center">
+            <v-col cols="5" class="mr-7">
               <player-performance-on-match
                 :unit-score="scoresOfWinners.map((h) => h.unitScore)"
                 :resource-scoure="scoresOfWinners.map((h) => h.resourceScore)"
@@ -97,7 +96,7 @@
                 :left="true"
               />
             </v-col>
-            <v-col cols="5">
+            <v-col cols="5" class="ml-7">
               <player-performance-on-match
                 :unit-score="scoresOfLoosers.map((h) => h.unitScore)"
                 :resource-scoure="scoresOfLoosers.map((h) => h.resourceScore)"
@@ -107,7 +106,6 @@
                 "
               />
             </v-col>
-            <v-col cols="1"></v-col>
           </v-row>
           <v-row v-if="isCompleteGame && matchIsFFA">
             <v-col cols="2" />


### PR DESCRIPTION
Issue: https://github.com/w3champions/w3champions-ui/issues/262

This fixes the larger team mode stats formatting as well as refactoring PlayerPerformanceOnMatch to be more responsive without having to check what team mode is currently being rendered. This should keep the design of the other game modes (1v1, 2v2) virtually the same.

Current design:
<img width="1195" alt="Screen Shot 2020-12-23 at 8 11 41 PM" src="https://user-images.githubusercontent.com/5152394/103051072-81fb4280-455b-11eb-9782-4b471d74776b.png">

Fix / Change:
<img width="1202" alt="Screen Shot 2020-12-23 at 8 16 56 PM" src="https://user-images.githubusercontent.com/5152394/103051186-d69ebd80-455b-11eb-8e9c-db564bbc3df0.png">