### PR TITLE
📦 Move typedefs to devdeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1254,9 +1254,9 @@
       "dev": true
     },
     "@types/chart.js": {
-      "version": "2.9.28",
-      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.28.tgz",
-      "integrity": "sha512-9YYhsxRngRJb0dkuaU5BezkF+zvvVHnwdRw+rtlahtFb4zqNf9YSgWsOq+dLYeh0fqsWmHUYLR64eNigh02F+w==",
+      "version": "2.9.29",
+      "resolved": "https://registry.npmjs.org/@types/chart.js/-/chart.js-2.9.29.tgz",
+      "integrity": "sha512-WOZMitUU3gHDM0oQsCsVivX+oDsIki93szcTmmUPBm39cCvAELBjokjSDVOoA3xiIEbb+jp17z/3S2tIqruwOQ==",
       "requires": {
         "moment": "^2.10.2"
       }
@@ -1265,6 +1265,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/@types/chartjs-plugin-annotation/-/chartjs-plugin-annotation-0.5.1.tgz",
       "integrity": "sha512-ruMXTjRVQwwbOtuNfFBHbqbhj497+D/VRmMPZiHv/GCupGwUf2l1TL7S1BTRYlP1Hengx798UwaOpAO+3+Sczw==",
+      "dev": true,
       "requires": {
         "@types/chart.js": "*",
         "moment": "^2.10.2"
@@ -1314,6 +1315,7 @@
       "version": "2.13.0",
       "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
       "integrity": "sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=",
+      "dev": true,
       "requires": {
         "moment": "*"
       }
@@ -1340,14 +1342,16 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@types/vue-markdown/-/vue-markdown-2.2.1.tgz",
       "integrity": "sha512-pqa1RU0GZybdtqqadOWT8rTwMSchH1PR+oYeenscTT8Nrq/gniL7hpibhH40+aZBjx3Ps0syaTSiSae4Inw7GQ==",
+      "dev": true,
       "requires": {
         "vue": "^2.5.16"
       }
     },
     "@types/vue-moment": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@types/vue-moment/-/vue-moment-4.0.1.tgz",
-      "integrity": "sha512-jWyTGzB/3jk/C6YhZ4zTj449nypBSqAf9Jrc0J7yJUDVl6zZcnuOsQvd+73atkF40Z7YYqLVauMQURRi5xBgug==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/vue-moment/-/vue-moment-4.0.2.tgz",
+      "integrity": "sha512-QMPYZ6GYNNgPJd8fjbF+exqza6WGma2bPOY5WgvX9hhQ6xPJdUn+lBpqzwSteVab11jwnGCqaSrQOEBPBL0Uew==",
+      "dev": true,
       "requires": {
         "moment": ">=2.24.0",
         "vue": "^2.6.10"

--- a/package.json
+++ b/package.json
@@ -12,11 +12,6 @@
   },
   "dependencies": {
     "@aspnet/signalr": "^1.1.4",
-    "@types/chart.js": "^2.9.28",
-    "@types/chartjs-plugin-annotation": "^0.5.1",
-    "@types/moment": "^2.13.0",
-    "@types/vue-markdown": "^2.2.1",
-    "@types/vue-moment": "^4.0.1",
     "babel-runtime": "^6.26.0",
     "chart.js": "^2.9.4",
     "chartjs-plugin-annotation": "^0.5.7",
@@ -39,7 +34,12 @@
     "vuex": "^3.5.1"
   },
   "devDependencies": {
+    "@types/chart.js": "^2.9.29",
+    "@types/chartjs-plugin-annotation": "^0.5.1",
     "@types/lodash": "^4.14.165",
+    "@types/moment": "^2.13.0",
+    "@types/vue-markdown": "^2.2.1",
+    "@types/vue-moment": "^4.0.2",
     "@typescript-eslint/eslint-plugin": "^3.10.1",
     "@typescript-eslint/parser": "^3.10.1",
     "@vue/cli-plugin-babel": "~4.4.6",


### PR DESCRIPTION
Tiny PR moving some `@types` dependencies to devDependencies.
That should improve build time on CI I guess 🤷 