### PR TITLE
fix issue #202 - profile picture correctly showing in /Rankings page

### DIFF
--- a/src/components/ladder/RankingsGrid.vue
+++ b/src/components/ladder/RankingsGrid.vue
@@ -358,7 +358,12 @@ export default class RankingsGrid extends Vue {
         playerInfo.isClassicPicture
       );
     } else {
-      return this.raceIcon(playerInfo.calculatedRace);
+      return getAvatarUrl(
+        playerInfo.selectedRace,
+        playerInfo.pictureId,
+        playerInfo.isClassicPicture
+      );
+      // old way to get race icon: return this.raceIcon(playerInfo.calculatedRace);
     }
   }
 


### PR DESCRIPTION
Simple change. Just put the 'usual' way of getting the picture. 
Is it expected behaviour that the function `getAvatarUrl` for `selectedRace = 16` and `pictureId = 0` (unselected) returns [TOTAL_0](https://storage.googleapis.com/w3champions-prod/integration/icons/raceAvatars/TOTAL_0.jpg) while getAvatarUrl for `selectedRace = 0` and `pictureId = 0` (sheep selected) returns [RANDOM_0](https://storage.googleapis.com/w3champions-prod/integration/icons/raceAvatars/RANDOM_0.jpg) , that in the end are the same?
If so this should be the correct solution i believe.

Cheers :)