### PR TITLE
Match summary pages not displaying

### DIFF
--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -333,47 +333,36 @@ export default class MatchDetailView extends Vue {
     await this.$store.direct.dispatch.matches.loadMatchDetail(this.matchId);
   }
 
-  private getPlayerScores(team: Team) : PlayerScore[] {
+  private getPlayerScores(team: Team): PlayerScore[] {
     let scores: PlayerScore[] = this.playerScores
       .filter((s) =>
-        team.players.some((player) =>
-          player.battleTag.startsWith(s.battleTag)
-        )
-      );
-
-    //Check if losers found
-    if (scores.length === 0) {
-      //Winners not found, so try matching without '#' portion of battleTag
-      scores = this.playerScores
-        .filter((s) =>
-          team.players.some((player) =>
+        team.players.some(
+          (player) =>
+            player.battleTag.startsWith(s.battleTag) ||
             s.battleTag
               .toLowerCase()
               .includes(player.battleTag.toLowerCase().split("#", 1)[0])
-          )
         )
-        .map((s) => {
-          const matchedPlayer = team.players.find((p) =>
-            s.battleTag
-              .toLowerCase()
-              .includes(p.battleTag.toLowerCase().split("#", 1)[0])
-          );
-          return {
-            ...s,
-            battleTag: matchedPlayer?.battleTag ?? "",
-          };
-        });
-    }
+      )
+      .map((s) => {
+        // Use the battleTag from the Player record
+        // since it is sometimes incorrect on the PlayerScore record
+        const matchedPlayer = team.players.find((p) =>
+          s.battleTag
+            .toLowerCase()
+            .includes(p.battleTag.toLowerCase().split("#", 1)[0])
+        );
+        return {
+          ...s,
+          battleTag: matchedPlayer?.battleTag ?? "",
+        };
+      });
 
     const playerScoreDictionary = _keyBy(scores, "battleTag");
 
     return team.players.map(
       (player) => playerScoreDictionary[player.battleTag]
     );
-  }
-
-  private findPlayerScore() {
-    
   }
 }
 </script>

--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -12,7 +12,11 @@
                   <br />
                   Season: {{ season }}
                 </v-card-subtitle>
-                <host-icon v-if="match.serverInfo && match.serverInfo.provider" :host="match.serverInfo" style="padding-right: 0px;"></host-icon>
+                <host-icon
+                  v-if="match.serverInfo && match.serverInfo.provider"
+                  :host="match.serverInfo"
+                  style="padding-right: 0px"
+                ></host-icon>
               </v-col>
               <v-col cols="4">
                 <team-match-info
@@ -47,7 +51,6 @@
               </v-col>
               <v-col cols="1" />
             </v-row>
-
           </v-card-title>
           <v-card-title v-if="isJubileeGame" class="justify-center">
             This is our {{ gameNumber }} Millionth game!
@@ -168,7 +171,7 @@ import HostIcon from "@/components/matches/HostIcon.vue";
     HeroIcon,
     MatchHiglights,
     TeamMatchInfo,
-    HostIcon
+    HostIcon,
   },
 })
 export default class MatchDetailView extends Vue {
@@ -235,16 +238,26 @@ export default class MatchDetailView extends Vue {
   get gameNumber() {
     let number = this.match.number / 1000000;
     switch (number) {
-      case 1: return "one"
-      case 2: return "two"
-      case 3: return "three"
-      case 4: return "four"
-      case 5: return "five"
-      case 6: return "six"
-      case 7: return "seven"
-      case 8: return "eight"
-      case 9: return "nine"
-      default: return "bazillion"
+      case 1:
+        return "one";
+      case 2:
+        return "two";
+      case 3:
+        return "three";
+      case 4:
+        return "four";
+      case 5:
+        return "five";
+      case 6:
+        return "six";
+      case 7:
+        return "seven";
+      case 8:
+        return "eight";
+      case 9:
+        return "nine";
+      default:
+        return "bazillion";
     }
   }
 
@@ -272,12 +285,45 @@ export default class MatchDetailView extends Vue {
   }
 
   get scoresOfWinners() {
-    const scoresOfWinners = this.playerScores.filter(
-      (s) =>
-        this.match.teams[0].players.some((player) =>
+    const winningTeam = this.match.teams[0];
+    let scoresOfWinners = this.playerScores
+      .filter((s) =>
+        winningTeam.players.some((player) =>
           player.battleTag.startsWith(s.battleTag)
         )
-    );
+      )
+      .map((s) => {
+        return {
+          ...s,
+          battleTag: winningTeam.players.find((p) =>
+            p.battleTag.startsWith(s.battleTag)
+          )?.battleTag,
+        };
+      });
+
+    //Check if winners found
+    if (scoresOfWinners.length === 0) {
+      //Winners not found, so try matching without '#' portion of battleTag
+      scoresOfWinners = this.playerScores
+        .filter((s) =>
+          winningTeam.players.some((player) =>
+            s.battleTag
+              .toLowerCase()
+              .includes(player.battleTag.toLowerCase().split("#", 1)[0])
+          )
+        )
+        .map((s) => {
+          return {
+            ...s,
+            battleTag: winningTeam.players.find((p) =>
+              s.battleTag
+                .toLowerCase()
+                .includes(p.battleTag.toLowerCase().split("#", 1)[0])
+            )?.battleTag,
+          };
+        });
+    }
+
     const scoresOfWinnersByBattleTag = _keyBy(scoresOfWinners, "battleTag");
 
     return this.match.teams[0].players.map(
@@ -286,12 +332,47 @@ export default class MatchDetailView extends Vue {
   }
 
   get scoresOfLoosers() {
-    const scoresOfLoosers = this.playerScores.filter(
-      (s) =>
-        this.match.teams[1].players.some((player) =>
+    const losingTeam = this.match.teams[1];
+    let scoresOfLoosers = this.playerScores
+      .filter((s) =>
+        losingTeam.players.some((player) =>
           player.battleTag.startsWith(s.battleTag)
         )
-    );
+      )
+      .map((s) => {
+        return {
+          ...s,
+          battleTag: losingTeam.players.find((p) =>
+            s.battleTag
+              .toLowerCase()
+              .includes(p.battleTag.toLowerCase().split("#", 1)[0])
+          )?.battleTag,
+        };
+      });
+
+    //Check if losers found
+    if (scoresOfLoosers.length === 0) {
+      //Winners not found, so try matching without '#' portion of battleTag
+      scoresOfLoosers = this.playerScores
+        .filter((s) =>
+          losingTeam.players.some((player) =>
+            s.battleTag
+              .toLowerCase()
+              .includes(player.battleTag.toLowerCase().split("#", 1)[0])
+          )
+        )
+        .map((s) => {
+          return {
+            ...s,
+            battleTag: losingTeam.players.find((p) =>
+              s.battleTag
+                .toLowerCase()
+                .includes(p.battleTag.toLowerCase().split("#", 1)[0])
+            )?.battleTag,
+          };
+        });
+    }
+    
     const scoresOfLoosersByBattleTag = _keyBy(scoresOfLoosers, "battleTag");
 
     return this.match.teams[1].players.map(
@@ -354,5 +435,4 @@ export default class MatchDetailView extends Vue {
   background-image: url("../assets/giphy.gif") !important;
   background-size: cover !important;
 }
-
 </style>


### PR DESCRIPTION
#317 
Add logic to handle incomplete battle tags. The issue is caused by incorrect battletag data stored in the database (i.e. 'iDentify' is in the db, but it should be `iDentify#11833`). The new logic will attempt to match the player if no matching battletag is found.

[w3champions/w3champions-statistic-service/#113](https://github.com/w3champions/w3champions-statistic-service/issues/113)