### PR TITLE
Fix match details for Flo matches

### DIFF
--- a/src/views/MatchDetail.vue
+++ b/src/views/MatchDetail.vue
@@ -275,7 +275,7 @@ export default class MatchDetailView extends Vue {
     const scoresOfWinners = this.playerScores.filter(
       (s) =>
         this.match.teams[0].players.some((player) =>
-          player.battleTag.startsWith(s.battleTag)
+          s.battleTag.startsWith(player.battleTag)
         )
     );
     const scoresOfWinnersByBattleTag = _keyBy(scoresOfWinners, "battleTag");
@@ -289,7 +289,7 @@ export default class MatchDetailView extends Vue {
     const scoresOfLoosers = this.playerScores.filter(
       (s) =>
         this.match.teams[1].players.some((player) =>
-          player.battleTag.startsWith(s.battleTag)
+          s.battleTag.startsWith(player.battleTag)
         )
     );
     const scoresOfLoosersByBattleTag = _keyBy(scoresOfLoosers, "battleTag");


### PR DESCRIPTION
players battletag include numbers after #

in playerScores those are missing

so it should work if we check if first starts with second (not other way)

![image](https://user-images.githubusercontent.com/38455533/104178328-91b3cb80-5423-11eb-97de-c2f0311222dc.png)

![image](https://user-images.githubusercontent.com/38455533/104178412-b445e480-5423-11eb-90ce-09572b78e497.png)
